### PR TITLE
Feature/context menu api

### DIFF
--- a/src/core/background.js
+++ b/src/core/background.js
@@ -2,44 +2,68 @@
  * Actually pushes the datapoint to the lambda function.
  */
 chrome.runtime.onMessage.addListener(
-  function(datapointDetails, sender, callback) {
-    datasource = datapointDetails['ds'];
-    username = datapointDetails['username'];
-    projects = datapointDetails['projects'];
-    datapoint = datapointDetails['datapoint'];
-
-    var xhr = new XMLHttpRequest();
-    var url = "https://push.metro.exchange";
-
-    xhr.open("POST", url, true);
-    xhr.setRequestHeader("Content-type", "application/json");
-
-    var data = {
-      "datasource": datasource,
-      "projects": projects,
-      "timestamp": Date.now(),
-      "data": datapoint,
-      "user": username
-    };
-
-    console.log("Pushing: ");
-    console.log(data);
-
-    // Only send datapoint to lambda if not in dev mode:
-    chrome.storage.sync.get("Settings-devModeCheckbox", function(items) {
-      if(chrome.runtime.error) {
-        return false;
-      } else {
-        if(items["Settings-devModeCheckbox"]) {
-          console.log("Not publishing the datapoint as running in dev mode.");
-        } else {
-          // Push with the API key:
-          getKeyAndPush(xhr, JSON.stringify(data));
+  function(message, sender, callback) {
+    // Receive all messages here and differentiate by the `type` field?
+    if(message['type'] == 'contextMenu') {
+      // This is the MetroClient telling the background script to create
+      // a `contextMenu` button...
+      chrome.contextMenus.create({
+        title: message.buttonTitle,
+        contexts: message.contexts,
+        onclick: function(info, tab) {
+          // When the button is clicked, we send a msg to the content script
+          // signaling to execute the function `functionName`
+          chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
+            chrome.tabs.sendMessage(tabs[0].id, {
+              type: message['type'],
+              functionName: message['functionName']
+            }, function(response) {
+              console.log(response);
+            });
+          });
         }
-      }
-    });
+      });
 
-    callback(JSON.stringify(data));
+    } else {
+      let datapointDetails = message;
+      datasource = datapointDetails['ds'];
+      username = datapointDetails['username'];
+      projects = datapointDetails['projects'];
+      datapoint = datapointDetails['datapoint'];
+
+      var xhr = new XMLHttpRequest();
+      var url = "https://push.metro.exchange";
+
+      xhr.open("POST", url, true);
+      xhr.setRequestHeader("Content-type", "application/json");
+
+      var data = {
+        "datasource": datasource,
+        "projects": projects,
+        "timestamp": Date.now(),
+        "data": datapoint,
+        "user": username
+      };
+
+      console.log("Pushing: ");
+      console.log(data);
+
+      // Only send datapoint to lambda if not in dev mode:
+      chrome.storage.sync.get("Settings-devModeCheckbox", function(items) {
+        if(chrome.runtime.error) {
+          return false;
+        } else {
+          if(items["Settings-devModeCheckbox"]) {
+            console.log("Not publishing the datapoint as running in dev mode.");
+          } else {
+            // Push with the API key:
+            getKeyAndPush(xhr, JSON.stringify(data));
+          }
+        }
+      });
+
+      callback(JSON.stringify(data));
+    }
   }
 );
 

--- a/src/core/scriptLoader.js
+++ b/src/core/scriptLoader.js
@@ -62,6 +62,24 @@ const runDataSource = function(datasource, scriptURL, schemaURL, projects, DS, u
           }
         },
 
+        addContextMenuButton: function(buttonDetails, buttonFunction) {
+          buttonDetails['type'] = 'contextMenu';
+          // Send message telling background script to create the `contextMenu` button
+          chrome.runtime.sendMessage(buttonDetails, function(response) {
+            console.log("addContextMenuButton response: " + response);
+          });
+
+          // Create receiver which checks `functionName` and calls the appropriate function
+          // NOTE: Should one listener handle all `contextMenu` buttons?
+          // ...Or is this ok? A new listener each time `addContextMenuButton` is called
+          chrome.extension.onMessage.addListener(function(message, sender, callback) {
+            if(message['type'] == buttonDetails['type']
+               && message.buttonFunction = buttonDetails.buttonFunction) {
+              buttonFunction();
+            }
+          })
+        },
+
         storeData: function(key, value) {
           // TODO: Can add validation here.
           let storageItem = {};

--- a/src/core/scriptLoader.js
+++ b/src/core/scriptLoader.js
@@ -62,7 +62,8 @@ const runDataSource = function(datasource, scriptURL, schemaURL, projects, DS, u
           }
         },
 
-        addContextMenuButton: function(buttonDetails, buttonFunction) {
+        createContextMenuButton: function(buttonDetails, buttonFunction) {
+          console.log("createContextMenuButton hit");
           buttonDetails['type'] = 'contextMenu';
           // Send message telling background script to create the `contextMenu` button
           chrome.runtime.sendMessage(buttonDetails, function(response) {
@@ -73,6 +74,8 @@ const runDataSource = function(datasource, scriptURL, schemaURL, projects, DS, u
           // NOTE: Should one listener handle all `contextMenu` buttons?
           // ...Or is this ok? A new listener each time `addContextMenuButton` is called
           chrome.extension.onMessage.addListener(function(message, sender, callback) {
+            console.log("Received message from background script");
+            console.log(message);
             if(message['type'] == buttonDetails['type']
                && message.buttonFunction = buttonDetails.buttonFunction) {
               buttonFunction();


### PR DESCRIPTION
Issue #8 asks for API functionality allowing DataSources to create `contextMenu` items (right-click menu buttons).

This is the basic implementation which lets developers create one button per DataSource via a call to `metroClient.createContextMenuButton()`.

A list is kept in `chrome.storage` of the created buttons, so that duplicates are not created every time a new page is loaded.