### PR TITLE
The contextMenu API now passes the context info to the callback

### DIFF
--- a/src/core/background.js
+++ b/src/core/background.js
@@ -116,7 +116,8 @@ const createContextMenuButton = function(message) {
       chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
         chrome.tabs.sendMessage(tabs[0].id, {
           type: message['type'],
-          functionName: message['functionName']
+          functionName: message['functionName'],
+          contextInfo: info // Add the info from the contextMenu context too
         }, function(response) {
           // Here we deal with the response from the buttonFunction
           if(response['status'] == 0) {

--- a/src/core/scriptLoader.js
+++ b/src/core/scriptLoader.js
@@ -89,7 +89,7 @@ const _createContextMenuButton = function(buttonDetails, buttonFunction) {
       // Create listener which checks `functionName` and calls the appropriate function
       chrome.runtime.onMessage.addListener(function(message, sender, callback) {
         if(message['type'] == buttonDetails['type'] && message['functionName'] == buttonDetails['functionName']) {
-          callback(buttonFunction());
+          callback(buttonFunction(message['contextInfo'])); // Pass the contextInfo from the contextMenu callback
         }
       });
     } else {


### PR DESCRIPTION
This is the right way for the `buttonFn` callback to get access to the selected text, image url, or other context info from the right-click event.